### PR TITLE
fix(core): add .js imports && vite config fix

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,9 +4,9 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
-import { validateProjectName } from './utils';
-import { getUserChoices } from './userPrompts';
-import { setupProject } from './projectSetup';
+import { validateProjectName } from './utils.js';
+import { getUserChoices } from './userPrompts.js';
+import { setupProject } from './projectSetup.js';
 
 program
   .version('1.1.1')

--- a/src/projectSetup.ts
+++ b/src/projectSetup.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import { UserChoices } from './types';
+import { UserChoices } from './types.js';
 import {
   installVite,
   installDependencies,
@@ -8,7 +8,7 @@ import {
   createFolderStructure,
   setupAxios,
   setupShadcn,
-} from './utils';
+} from './utils.js';
 
 export const setupProject = async (
   projectDir: string,

--- a/src/userPrompts.ts
+++ b/src/userPrompts.ts
@@ -1,5 +1,6 @@
 import inquirer from 'inquirer';
-import { UserChoices } from './types';
+
+import { UserChoices } from './types.js';
 
 export const getUserChoices = async (
   skipPrompts: boolean

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,8 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 import { execSync } from 'child_process';
-import { UserChoices } from './types';
+
+import { UserChoices } from './types.js';
 
 export const validateProjectName = (
   projectName: string,
@@ -150,30 +151,33 @@ export const setupShadcn = async (projectDir: string) => {
     process.exit(1);
   }
 
-  // 2. Update vite.config.ts with alias
+  // 2. Overwrite vite.config.ts with hardcoded content
   const viteConfigPath = path.join(projectDir, 'vite.config.ts');
-  try {
-    if (fs.existsSync(viteConfigPath)) {
-      let viteConfig = fs.readFileSync(viteConfigPath, 'utf-8');
 
-      if (!viteConfig.includes('alias')) {
-        const aliasConfig = `
+  // Hardcoded content for vite.config.ts
+  const viteConfigContent = `import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+// https://vitejs.dev/config/
+export default defineConfig({
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src")
-    }
-  },`;
-        // Insert alias config inside the defineConfig block
-        viteConfig = viteConfig.replace(
-          /(defineConfig\({)/,
-          `$1${aliasConfig}`
-        );
-        fs.writeFileSync(viteConfigPath, viteConfig);
-        console.log(chalk.green('vite.config.ts updated with alias.'));
-      }
-    }
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  plugins: [react()],
+});
+`;
+
+  try {
+    // Write or overwrite vite.config.ts with hardcoded content
+    fs.writeFileSync(viteConfigPath, viteConfigContent);
+    console.log(
+      chalk.green('vite.config.ts file created/updated successfully.')
+    );
   } catch (error) {
-    console.error(chalk.red('Error updating vite.config.ts:'), error);
+    console.error(chalk.red('Error creating/updating vite.config.ts:'), error);
     process.exit(1);
   }
 


### PR DESCRIPTION
## Description

Resolves:
https://github.com/dane-whitfield/vtta/issues/2
&&
https://github.com/dane-whitfield/vtta/issues/1

## What?

- Add `.js` extensions to import paths.
- Add hardcoded `vite.config.js` file contents.

## Why?

- App was failing to build and run due to import paths not including the `.js` extension (Node20 requirement)
- `vite.config.js` was missing the `path` import which caused an error when running the scaffolded project.

## Checklist

- [x] I have followed the coding guidelines.
- [x] Added tests if applicable and tests are passing locally.
- [x] Linting is passing.
