### PR TITLE
fix(git): fix CODEOWNERS file error

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,3 @@
 # All files in the repository will require owner review
 
 - @danewhitfield
-
-# For files in the /src/ directory, require owner review
-
-/src/ @danewhitfield
-
-# For JavaScript files, require owner review
-
-\*.js @danewhitfield


### PR DESCRIPTION
## Description

There's an error within the CODEOWNERS file, involving a path that wasn't being escaped properly.

## What?

Remove unnecessary paths.

## Why?

Not need and was causing errors.

## Checklist

- [x] I have followed the coding guidelines.
- [x] Added tests if applicable and tests are passing locally.
- [x] Linting is passing.
