### PR TITLE
feat: adds vitest project setup option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,9 @@
 ## [1.2.1] - 2024-09-24
 
 - Fixes `/dist/src` entry path error for builds
+
+## [1.3.0] - 2024-09-24
+
+- Implements feature request:
+  - https://github.com/dane-whitfield/vtta/issues/9
+  - adds new vitest option for both JavaScript and TypeScript setups.

--- a/package.json
+++ b/package.json
@@ -1,54 +1,48 @@
 {
-  "name": "vtta",
-  "version": "1.2.1",
-  "description": "A CLI to bootstrap a new Vite project with customisable options",
-  "type": "module",
-  "main": "dist/src/cli.js",
-  "types": "dist/src/cli.d.ts",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/dane-whitfield/vtta.git"
-  },
-  "bin": {
-    "vtta": "./dist/src/cli.js"
-  },
-  "engines": {
-    "node": ">=18"
-  },
-  "scripts": {
-    "build": "rm -rf dist && tsc",
-    "start": "node --no-warnings dist/src/cli.js",
-    "prepublishOnly": "npm run build",
-    "lint": "npm run biome:check",
-    "biome:check": "biome check .",
-    "biome:format": "biome format .",
-    "prepare": "husky",
-    "test": "vitest",
-    "test:ui": "vitest --ui",
-    "coverage": "vitest run --coverage"
-  },
-  "keywords": [
-    "vite",
-    "react",
-    "typescript",
-    "tailwind",
-    "cli"
-  ],
-  "author": "Dane Whitfield",
-  "license": "MIT",
-  "dependencies": {
-    "chalk": "^5.3.0",
-    "commander": "^10.0.1",
-    "fs-extra": "^11.2.0",
-    "inquirer": "^10.2.2"
-  },
-  "devDependencies": {
-    "@types/fs-extra": "^11.0.4",
-    "@types/node": "^22.5.5",
-    "@vitest/ui": "^2.1.1",
-    "biome": "^0.3.3",
-    "husky": "^9.1.6",
-    "typescript": "^5.6.2",
-    "vitest": "^2.1.1"
-  }
+	"name": "vtta",
+	"version": "1.3.0",
+	"description": "A CLI to bootstrap a new Vite project with customisable options",
+	"type": "module",
+	"main": "dist/src/cli.js",
+	"types": "dist/src/cli.d.ts",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/dane-whitfield/vtta.git"
+	},
+	"bin": {
+		"vtta": "./dist/src/cli.js"
+	},
+	"engines": {
+		"node": ">=18"
+	},
+	"scripts": {
+		"build": "rm -rf dist && tsc",
+		"start": "node --no-warnings dist/src/cli.js",
+		"prepublishOnly": "npm run build",
+		"lint": "npm run biome:check",
+		"biome:check": "biome check .",
+		"biome:format": "biome format .",
+		"prepare": "husky",
+		"test": "vitest",
+		"test:ui": "vitest --ui",
+		"coverage": "vitest run --coverage"
+	},
+	"keywords": ["vite", "react", "typescript", "tailwind", "cli"],
+	"author": "Dane Whitfield",
+	"license": "MIT",
+	"dependencies": {
+		"chalk": "^5.3.0",
+		"commander": "^10.0.1",
+		"fs-extra": "^11.2.0",
+		"inquirer": "^10.2.2"
+	},
+	"devDependencies": {
+		"@types/fs-extra": "^11.0.4",
+		"@types/node": "^22.5.5",
+		"@vitest/ui": "^2.1.1",
+		"biome": "^0.3.3",
+		"husky": "^9.1.6",
+		"typescript": "^5.6.2",
+		"vitest": "^2.1.1"
+	}
 }

--- a/src/__tests__/projectSetup.spec.ts
+++ b/src/__tests__/projectSetup.spec.ts
@@ -1,114 +1,197 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import chalk from 'chalk';
-import { setupProject } from '../projectSetup'; // Assuming the main file is setupProject.ts
+import { describe, it, expect, vi, afterEach } from "vitest";
+import chalk from "chalk";
+import { setupProject } from "../projectSetup"; // Assuming the main file is setupProject.ts
 import {
-  installVite,
-  installDependencies,
-  setupTailwind,
-  createFolderStructure,
-  setupAxios,
-  setupShadcn,
-} from '../utils';
+	installVite,
+	installDependencies,
+	setupTailwind,
+	createFolderStructure,
+	setupAxios,
+	setupShadcn,
+	setupVitest,
+} from "../utils";
 
 // Mock the utils
-vi.mock('../utils', () => ({
-  installVite: vi.fn(),
-  installDependencies: vi.fn(),
-  setupTailwind: vi.fn(),
-  createFolderStructure: vi.fn(),
-  setupAxios: vi.fn(),
-  setupShadcn: vi.fn(),
+vi.mock("../utils", () => ({
+	installVite: vi.fn(),
+	installDependencies: vi.fn(),
+	setupTailwind: vi.fn(),
+	createFolderStructure: vi.fn(),
+	setupAxios: vi.fn(),
+	setupShadcn: vi.fn(),
+	setupVitest: vi.fn(),
 }));
 
 // Helper to spy on console.log
-const spyLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+const spyLog = vi.spyOn(console, "log").mockImplementation(() => {});
 
-describe('setupProject', () => {
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
+describe("setupProject", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
 
-  it('should install Vite with TypeScript if selected', async () => {
-    const projectDir = 'test-project';
-    const userChoices = { typescript: true, tailwind: false, axios: false, shadcn: false };
+	it("should install Vite with TypeScript if selected", async () => {
+		const projectDir = "test-project";
+		const userChoices = {
+			typescript: true,
+			tailwind: false,
+			axios: false,
+			shadcn: false,
+		};
 
-    await setupProject(projectDir, userChoices);
+		await setupProject(projectDir, userChoices);
 
-    expect(installVite).toHaveBeenCalledWith(true);
-    expect(installDependencies).toHaveBeenCalledWith(userChoices);
-    expect(createFolderStructure).toHaveBeenCalledWith(projectDir);
-    expect(setupTailwind).not.toHaveBeenCalled();
-    expect(setupAxios).not.toHaveBeenCalled();
-    expect(setupShadcn).not.toHaveBeenCalled();
-  });
+		expect(installVite).toHaveBeenCalledWith(true);
+		expect(installDependencies).toHaveBeenCalledWith(userChoices);
+		expect(createFolderStructure).toHaveBeenCalledWith(projectDir);
+		expect(setupTailwind).not.toHaveBeenCalled();
+		expect(setupAxios).not.toHaveBeenCalled();
+		expect(setupShadcn).not.toHaveBeenCalled();
+	});
 
-  it('should set up Tailwind if selected', async () => {
-    const projectDir = 'test-project';
-    const userChoices = { typescript: false, tailwind: true, axios: false, shadcn: false };
+	it("should set up Tailwind if selected", async () => {
+		const projectDir = "test-project";
+		const userChoices = {
+			typescript: false,
+			tailwind: true,
+			axios: false,
+			shadcn: false,
+		};
 
-    await setupProject(projectDir, userChoices);
+		await setupProject(projectDir, userChoices);
 
-    expect(installVite).toHaveBeenCalledWith(false);
-    expect(installDependencies).toHaveBeenCalledWith(userChoices);
-    expect(setupTailwind).toHaveBeenCalledWith(projectDir);
-    expect(createFolderStructure).toHaveBeenCalledWith(projectDir);
-    expect(setupAxios).not.toHaveBeenCalled();
-    expect(setupShadcn).not.toHaveBeenCalled();
-  });
+		expect(installVite).toHaveBeenCalledWith(false);
+		expect(installDependencies).toHaveBeenCalledWith(userChoices);
+		expect(setupTailwind).toHaveBeenCalledWith(projectDir);
+		expect(createFolderStructure).toHaveBeenCalledWith(projectDir);
+		expect(setupAxios).not.toHaveBeenCalled();
+		expect(setupShadcn).not.toHaveBeenCalled();
+	});
 
-  it('should set up Axios if selected', async () => {
-    const projectDir = 'test-project';
-    const userChoices = { typescript: false, tailwind: false, axios: true, shadcn: false, router: false };
+	it("should set up Axios if selected", async () => {
+		const projectDir = "test-project";
+		const userChoices = {
+			typescript: false,
+			tailwind: false,
+			axios: true,
+			shadcn: false,
+			router: false,
+		};
 
-    await setupProject(projectDir, userChoices);
+		await setupProject(projectDir, userChoices);
 
-    expect(installVite).toHaveBeenCalledWith(false);
-    expect(installDependencies).toHaveBeenCalledWith(userChoices);
-    expect(setupAxios).toHaveBeenCalledWith(projectDir);
-    expect(setupShadcn).not.toHaveBeenCalled();
-    expect(spyLog).not.toHaveBeenCalled();
-  });
+		expect(installVite).toHaveBeenCalledWith(false);
+		expect(installDependencies).toHaveBeenCalledWith(userChoices);
+		expect(setupAxios).toHaveBeenCalledWith(projectDir);
+		expect(setupShadcn).not.toHaveBeenCalled();
+		expect(spyLog).not.toHaveBeenCalled();
+	});
 
-  it('should set up Shadcn if both Tailwind and Shadcn are selected', async () => {
-    const projectDir = 'test-project';
-    const userChoices = { typescript: false, tailwind: true, axios: false, shadcn: true };
+	it("should set up Shadcn if both Tailwind and Shadcn are selected", async () => {
+		const projectDir = "test-project";
+		const userChoices = {
+			typescript: false,
+			tailwind: true,
+			axios: false,
+			shadcn: true,
+		};
 
-    await setupProject(projectDir, userChoices);
+		await setupProject(projectDir, userChoices);
 
-    expect(installVite).toHaveBeenCalledWith(false);
-    expect(installDependencies).toHaveBeenCalledWith(userChoices);
-    expect(setupTailwind).toHaveBeenCalledWith(projectDir);
-    expect(setupShadcn).toHaveBeenCalledWith(projectDir);
-    expect(spyLog).not.toHaveBeenCalled();
-  });
+		expect(installVite).toHaveBeenCalledWith(false);
+		expect(installDependencies).toHaveBeenCalledWith(userChoices);
+		expect(setupTailwind).toHaveBeenCalledWith(projectDir);
+		expect(setupShadcn).toHaveBeenCalledWith(projectDir);
+		expect(spyLog).not.toHaveBeenCalled();
+	});
 
-  it('should not set up Shadcn and log an error if Tailwind is not selected', async () => {
-    const projectDir = 'test-project';
-    const userChoices = { typescript: false, tailwind: false, axios: false, shadcn: true };
+	it("should not set up Shadcn and log an error if Tailwind is not selected", async () => {
+		const projectDir = "test-project";
+		const userChoices = {
+			typescript: false,
+			tailwind: false,
+			axios: false,
+			shadcn: true,
+		};
 
-    await setupProject(projectDir, userChoices);
+		await setupProject(projectDir, userChoices);
 
-    expect(installVite).toHaveBeenCalledWith(false);
-    expect(installDependencies).toHaveBeenCalledWith(userChoices);
-    expect(setupShadcn).not.toHaveBeenCalled();
-    expect(spyLog).toHaveBeenCalledWith(
-      chalk.red(
-        'Shadcn requires Tailwind and cannot be used without it. Please start again and choose to install Tailwind if you wish to use Shadcn.'
-      )
-    );
-  });
+		expect(installVite).toHaveBeenCalledWith(false);
+		expect(installDependencies).toHaveBeenCalledWith(userChoices);
+		expect(setupShadcn).not.toHaveBeenCalled();
+		expect(spyLog).toHaveBeenCalledWith(
+			chalk.red(
+				"Shadcn requires Tailwind and cannot be used without it. Please start again and choose to install Tailwind if you wish to use Shadcn.",
+			),
+		);
+	});
 
-  it('should handle a full setup with Tailwind, Axios, and Shadcn', async () => {
-    const projectDir = 'test-project';
-    const userChoices = { typescript: true, tailwind: true, axios: true, shadcn: true };
+	it("should handle a full setup with Tailwind, Axios, and Shadcn", async () => {
+		const projectDir = "test-project";
+		const userChoices = {
+			typescript: true,
+			tailwind: true,
+			axios: true,
+			shadcn: true,
+		};
 
-    await setupProject(projectDir, userChoices);
+		await setupProject(projectDir, userChoices);
 
-    expect(installVite).toHaveBeenCalledWith(true);
-    expect(installDependencies).toHaveBeenCalledWith(userChoices);
-    expect(setupTailwind).toHaveBeenCalledWith(projectDir);
-    expect(setupAxios).toHaveBeenCalledWith(projectDir);
-    expect(setupShadcn).toHaveBeenCalledWith(projectDir);
-    expect(spyLog).not.toHaveBeenCalled();
-  });
+		expect(installVite).toHaveBeenCalledWith(true);
+		expect(installDependencies).toHaveBeenCalledWith(userChoices);
+		expect(setupTailwind).toHaveBeenCalledWith(projectDir);
+		expect(setupAxios).toHaveBeenCalledWith(projectDir);
+		expect(setupShadcn).toHaveBeenCalledWith(projectDir);
+		expect(spyLog).not.toHaveBeenCalled();
+	});
+
+	it("should set up Vitest with JavaScript if TypeScript is not selected", async () => {
+		const projectDir = "test-project";
+		const userChoices = {
+			typescript: false,
+			tailwind: false,
+			axios: false,
+			shadcn: false,
+			vitest: true,
+		};
+
+		await setupProject(projectDir, userChoices);
+
+		expect(setupVitest).toHaveBeenCalledWith(projectDir, false);
+	});
+
+	it("should set up Vitest with TypeScript if TypeScript is selected", async () => {
+		const projectDir = "test-project";
+		const userChoices = {
+			typescript: true,
+			tailwind: false,
+			axios: false,
+			shadcn: false,
+			vitest: true,
+		};
+
+		await setupProject(projectDir, userChoices);
+
+		expect(setupVitest).toHaveBeenCalledWith(projectDir, true);
+	});
+
+	it("should handle a full setup including Vitest", async () => {
+		const projectDir = "test-project";
+		const userChoices = {
+			typescript: true,
+			tailwind: true,
+			axios: true,
+			shadcn: true,
+			vitest: true,
+		};
+
+		await setupProject(projectDir, userChoices);
+
+		expect(installVite).toHaveBeenCalledWith(true);
+		expect(installDependencies).toHaveBeenCalledWith(userChoices);
+		expect(setupTailwind).toHaveBeenCalledWith(projectDir);
+		expect(setupAxios).toHaveBeenCalledWith(projectDir);
+		expect(setupShadcn).toHaveBeenCalledWith(projectDir);
+		expect(setupVitest).toHaveBeenCalledWith(projectDir, true);
+	});
 });

--- a/src/projectSetup.ts
+++ b/src/projectSetup.ts
@@ -1,41 +1,46 @@
-import chalk from 'chalk';
+import chalk from "chalk";
 
-import { UserChoices } from './types.js';
+import type { UserChoices } from "./types.js";
 import {
-  installVite,
-  installDependencies,
-  setupTailwind,
-  createFolderStructure,
-  setupAxios,
-  setupShadcn,
-} from './utils.js';
+	installVite,
+	installDependencies,
+	setupTailwind,
+	createFolderStructure,
+	setupAxios,
+	setupShadcn,
+	setupVitest,
+} from "./utils.js";
 
 export const setupProject = async (
-  projectDir: string,
-  userChoices: UserChoices
+	projectDir: string,
+	userChoices: UserChoices,
 ) => {
-  await installVite(userChoices.typescript);
-  await installDependencies(userChoices);
+	await installVite(userChoices.typescript);
+	await installDependencies(userChoices);
 
-  if (userChoices.tailwind) {
-    await setupTailwind(projectDir);
-  }
+	if (userChoices.tailwind) {
+		await setupTailwind(projectDir);
+	}
 
-  createFolderStructure(projectDir);
+	createFolderStructure(projectDir);
 
-  if (userChoices.axios) {
-    await setupAxios(projectDir);
-  }
+	if (userChoices.axios) {
+		await setupAxios(projectDir);
+	}
 
-  if (userChoices.shadcn) {
-    if (userChoices.tailwind) {
-      await setupShadcn(projectDir);
-    } else {
-      console.log(
-        chalk.red(
-          'Shadcn requires Tailwind and cannot be used without it. Please start again and choose to install Tailwind if you wish to use Shadcn.'
-        )
-      );
-    }
-  }
+	if (userChoices.shadcn) {
+		if (userChoices.tailwind) {
+			await setupShadcn(projectDir);
+		} else {
+			console.log(
+				chalk.red(
+					"Shadcn requires Tailwind and cannot be used without it. Please start again and choose to install Tailwind if you wish to use Shadcn.",
+				),
+			);
+		}
+	}
+
+	if (userChoices.vitest) {
+		await setupVitest(projectDir, userChoices.typescript);
+	}
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
 export interface UserChoices {
-  typescript: boolean;
-  tailwind: boolean;
-  router: boolean;
-  axios: boolean;
-  shadcn: boolean;
+	typescript: boolean;
+	tailwind: boolean;
+	router: boolean;
+	axios: boolean;
+	shadcn: boolean;
+	vitest: boolean;
 }

--- a/src/userPrompts.ts
+++ b/src/userPrompts.ts
@@ -1,50 +1,57 @@
-import inquirer from 'inquirer';
+import inquirer from "inquirer";
 
-import { UserChoices } from './types.js';
+import { UserChoices } from "./types.js";
 
 export const getUserChoices = async (
-  skipPrompts: boolean
+	skipPrompts: boolean,
 ): Promise<UserChoices> => {
-  if (skipPrompts) {
-    return {
-      typescript: true,
-      tailwind: true,
-      router: true,
-      axios: true,
-      shadcn: true,
-    };
-  }
+	if (skipPrompts) {
+		return {
+			typescript: true,
+			tailwind: true,
+			router: true,
+			axios: true,
+			shadcn: true,
+			vitest: true,
+		};
+	}
 
-  return inquirer.prompt([
-    {
-      type: 'confirm',
-      name: 'typescript',
-      message: 'Do you want to use TypeScript?',
-      default: true,
-    },
-    {
-      type: 'confirm',
-      name: 'tailwind',
-      message: 'Do you want to use Tailwind CSS?',
-      default: true,
-    },
-    {
-      type: 'confirm',
-      name: 'router',
-      message: 'Do you want to install React Router?',
-      default: true,
-    },
-    {
-      type: 'confirm',
-      name: 'axios',
-      message: 'Do you want to initialise Axios?',
-      default: true,
-    },
-    {
-      type: 'confirm',
-      name: 'shadcn',
-      message: 'Do you want to include shadcn/ui for accessible UI components?',
-      default: true,
-    },
-  ]);
+	return inquirer.prompt([
+		{
+			type: "confirm",
+			name: "typescript",
+			message: "Do you want to use TypeScript?",
+			default: true,
+		},
+		{
+			type: "confirm",
+			name: "tailwind",
+			message: "Do you want to use Tailwind CSS?",
+			default: true,
+		},
+		{
+			type: "confirm",
+			name: "router",
+			message: "Do you want to install React Router?",
+			default: true,
+		},
+		{
+			type: "confirm",
+			name: "axios",
+			message: "Do you want to initialise Axios?",
+			default: true,
+		},
+		{
+			type: "confirm",
+			name: "shadcn",
+			message: "Do you want to include shadcn/ui for accessible UI components?",
+			default: true,
+		},
+		{
+			type: "confirm",
+			name: "vitest",
+			message: "Do you want to set up Vitest for testing?",
+			default: true,
+		},
+	]);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,58 +1,58 @@
-import chalk from 'chalk';
-import fs from 'fs-extra';
-import path from 'path';
-import { execSync } from 'child_process';
+import chalk from "chalk";
+import fs from "fs-extra";
+import path from "path";
+import { execSync } from "child_process";
 
-import packageJson from '../package.json' assert { type: 'json' };
-import { UserChoices } from './types.js';
+import packageJson from "../package.json" assert { type: "json" };
+import { UserChoices } from "./types.js";
 
 export const validateProjectName = (
-  projectName: string,
-  projectDir: string
+	projectName: string,
+	projectDir: string,
 ) => {
-  if (fs.existsSync(projectDir)) {
-    console.error(chalk.red(`Error: Directory ${projectName} already exists.`));
-    process.exit(1);
-  }
+	if (fs.existsSync(projectDir)) {
+		console.error(chalk.red(`Error: Directory ${projectName} already exists.`));
+		process.exit(1);
+	}
 };
 
 export const createFolderStructure = (projectDir: string) => {
-  console.log(chalk.yellow('Creating folder structure...'));
-  ['src/components', 'src/pages', 'src/utils', 'src/hooks'].forEach((dir) => {
-    fs.mkdirSync(path.join(projectDir, dir), { recursive: true });
-  });
+	console.log(chalk.yellow("Creating folder structure..."));
+	["src/components", "src/pages", "src/utils", "src/hooks"].forEach((dir) => {
+		fs.mkdirSync(path.join(projectDir, dir), { recursive: true });
+	});
 };
 
 export const installVite = async (useTypescript: boolean) => {
-  console.log(chalk.yellow('Initialising Vite project...'));
-  const template = useTypescript ? 'react-ts' : 'react';
-  execSync(`npm init vite@latest . -- --template ${template}`, {
-    stdio: 'inherit',
-  });
+	console.log(chalk.yellow("Initialising Vite project..."));
+	const template = useTypescript ? "react-ts" : "react";
+	execSync(`npm init vite@latest . -- --template ${template}`, {
+		stdio: "inherit",
+	});
 };
 
 export const installDependencies = async (userChoices: UserChoices) => {
-  if (userChoices.axios) {
-    console.log(chalk.yellow('Installing axios...'));
-    execSync('npm install axios', { stdio: 'inherit' });
-  }
+	if (userChoices.axios) {
+		console.log(chalk.yellow("Installing axios..."));
+		execSync("npm install axios", { stdio: "inherit" });
+	}
 
-  if (userChoices.tailwind) {
-    console.log(chalk.yellow('Installing Tailwind CSS...'));
-    execSync('npm install -D tailwindcss postcss autoprefixer', {
-      stdio: 'inherit',
-    });
-    execSync('npx tailwindcss init -p', { stdio: 'inherit' });
-  }
+	if (userChoices.tailwind) {
+		console.log(chalk.yellow("Installing Tailwind CSS..."));
+		execSync("npm install -D tailwindcss postcss autoprefixer", {
+			stdio: "inherit",
+		});
+		execSync("npx tailwindcss init -p", { stdio: "inherit" });
+	}
 
-  if (userChoices.router) {
-    console.log(chalk.yellow('Installing React Router...'));
-    execSync('npm install react-router-dom', { stdio: 'inherit' });
-  }
+	if (userChoices.router) {
+		console.log(chalk.yellow("Installing React Router..."));
+		execSync("npm install react-router-dom", { stdio: "inherit" });
+	}
 };
 
 export const setupTailwind = async (projectDir: string) => {
-  const tailwindConfig = `
+	const tailwindConfig = `
 module.exports = {
   content: [
     "./index.html",
@@ -64,18 +64,18 @@ module.exports = {
   plugins: [],
 }
   `;
-  fs.writeFileSync(path.join(projectDir, 'tailwind.config.js'), tailwindConfig);
+	fs.writeFileSync(path.join(projectDir, "tailwind.config.js"), tailwindConfig);
 
-  const indexCSS = `
+	const indexCSS = `
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
   `;
-  fs.writeFileSync(path.join(projectDir, 'src/index.css'), indexCSS);
+	fs.writeFileSync(path.join(projectDir, "src/index.css"), indexCSS);
 };
 
 export const setupAxios = async (projectDir: string) => {
-  const apiContent = `
+	const apiContent = `
 import axios from 'axios';
 
 const api = axios.create({
@@ -89,20 +89,20 @@ export const getSomething = async () => {
 	return data;
 };
   `;
-  fs.writeFileSync(path.join(projectDir, 'src/utils/api.ts'), apiContent);
+	fs.writeFileSync(path.join(projectDir, "src/utils/api.ts"), apiContent);
 
-  const envExampleContent = `VITE_API_URL=your_api_url_here`;
-  fs.writeFileSync(path.join(projectDir, '.env.example'), envExampleContent);
+	const envExampleContent = `VITE_API_URL=your_api_url_here`;
+	fs.writeFileSync(path.join(projectDir, ".env.example"), envExampleContent);
 };
 
 export const setupShadcn = async (projectDir: string) => {
-  console.log(chalk.yellow('Setting up shadcn/ui...'));
+	console.log(chalk.yellow("Setting up shadcn/ui..."));
 
-  // 1. Update tsconfig.json and tsconfig.app.json with hardcoded content first
-  const tsconfigPath = path.join(projectDir, 'tsconfig.json');
-  const tsconfigAppPath = path.join(projectDir, 'tsconfig.app.json');
+	// 1. Update tsconfig.json and tsconfig.app.json with hardcoded content first
+	const tsconfigPath = path.join(projectDir, "tsconfig.json");
+	const tsconfigAppPath = path.join(projectDir, "tsconfig.app.json");
 
-  const tsconfigContent = `{
+	const tsconfigContent = `{
     "compilerOptions": {
       "target": "ES2020",
       "useDefineForClassFields": true,
@@ -134,29 +134,29 @@ export const setupShadcn = async (projectDir: string) => {
     "references": [{ "path": "./tsconfig.node.json" }]
   }`;
 
-  // Write tsconfig.json
-  try {
-    fs.writeFileSync(tsconfigPath, tsconfigContent);
-    console.log(chalk.green('tsconfig.json updated successfully.'));
-  } catch (error) {
-    console.error(chalk.red('Error updating tsconfig.json:'), error);
-    process.exit(1);
-  }
+	// Write tsconfig.json
+	try {
+		fs.writeFileSync(tsconfigPath, tsconfigContent);
+		console.log(chalk.green("tsconfig.json updated successfully."));
+	} catch (error) {
+		console.error(chalk.red("Error updating tsconfig.json:"), error);
+		process.exit(1);
+	}
 
-  // Write tsconfig.app.json (if needed)
-  try {
-    fs.writeFileSync(tsconfigAppPath, tsconfigContent);
-    console.log(chalk.green('tsconfig.app.json updated successfully.'));
-  } catch (error) {
-    console.error(chalk.red('Error updating tsconfig.app.json:'), error);
-    process.exit(1);
-  }
+	// Write tsconfig.app.json (if needed)
+	try {
+		fs.writeFileSync(tsconfigAppPath, tsconfigContent);
+		console.log(chalk.green("tsconfig.app.json updated successfully."));
+	} catch (error) {
+		console.error(chalk.red("Error updating tsconfig.app.json:"), error);
+		process.exit(1);
+	}
 
-  // 2. Overwrite vite.config.ts with hardcoded content
-  const viteConfigPath = path.join(projectDir, 'vite.config.ts');
+	// 2. Overwrite vite.config.ts with hardcoded content
+	const viteConfigPath = path.join(projectDir, "vite.config.ts");
 
-  // Hardcoded content for vite.config.ts
-  const viteConfigContent = `import { defineConfig } from 'vite';
+	// Hardcoded content for vite.config.ts
+	const viteConfigContent = `import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
@@ -171,20 +171,20 @@ export default defineConfig({
 });
 `;
 
-  try {
-    // Write or overwrite vite.config.ts with hardcoded content
-    fs.writeFileSync(viteConfigPath, viteConfigContent);
-    console.log(
-      chalk.green('vite.config.ts file created/updated successfully.')
-    );
-  } catch (error) {
-    console.error(chalk.red('Error creating/updating vite.config.ts:'), error);
-    process.exit(1);
-  }
+	try {
+		// Write or overwrite vite.config.ts with hardcoded content
+		fs.writeFileSync(viteConfigPath, viteConfigContent);
+		console.log(
+			chalk.green("vite.config.ts file created/updated successfully."),
+		);
+	} catch (error) {
+		console.error(chalk.red("Error creating/updating vite.config.ts:"), error);
+		process.exit(1);
+	}
 
-  // 3. Write the `components.json` file with default settings.
-  const componentsJsonPath = path.join(projectDir, 'components.json');
-  const componentsJsonContent = `{
+	// 3. Write the `components.json` file with default settings.
+	const componentsJsonPath = path.join(projectDir, "components.json");
+	const componentsJsonContent = `{
     "$schema": "https://ui.shadcn.com/schema.json",
     "style": "new-york",
     "rsc": false,
@@ -202,54 +202,125 @@ export default defineConfig({
     }
   }`;
 
-  try {
-    fs.writeFileSync(componentsJsonPath, componentsJsonContent);
-    console.log(
-      chalk.green(
-        `components.json file created successfully at: ${componentsJsonPath}`
-      )
-    );
-  } catch (error) {
-    console.error(chalk.red('Error creating components.json file:'), error);
-    process.exit(1);
-  }
+	try {
+		fs.writeFileSync(componentsJsonPath, componentsJsonContent);
+		console.log(
+			chalk.green(
+				`components.json file created successfully at: ${componentsJsonPath}`,
+			),
+		);
+	} catch (error) {
+		console.error(chalk.red("Error creating components.json file:"), error);
+		process.exit(1);
+	}
 
-  // 4. Install the shadcn/ui dependencies.
-  try {
-    console.log(chalk.yellow('Installing shadcn/ui dependencies...'));
+	// 4. Install the shadcn/ui dependencies.
+	try {
+		console.log(chalk.yellow("Installing shadcn/ui dependencies..."));
 
-    // Install shadcn-ui package
-    execSync('npm install shadcn-ui', { stdio: 'inherit' });
+		// Install shadcn-ui package
+		execSync("npm install shadcn-ui", { stdio: "inherit" });
 
-    console.log(chalk.green('shadcn/ui dependencies installed successfully!'));
+		console.log(chalk.green("shadcn/ui dependencies installed successfully!"));
 
-    // 5. Add basic starter button component after everything is in place
-    execSync('npx shadcn@latest add button', { stdio: 'inherit' });
-    console.log(chalk.green('Button component installed successfully.'));
-  } catch (error) {
-    console.error(
-      chalk.red('An error occurred during shadcn/ui installation:'),
-      error
-    );
-    process.exit(1);
-  }
+		// 5. Add basic starter button component after everything is in place
+		execSync("npx shadcn@latest add button", { stdio: "inherit" });
+		console.log(chalk.green("Button component installed successfully."));
+	} catch (error) {
+		console.error(
+			chalk.red("An error occurred during shadcn/ui installation:"),
+			error,
+		);
+		process.exit(1);
+	}
 
-  console.log(chalk.green('ShadCN setup completed successfully.'));
+	console.log(chalk.green("ShadCN setup completed successfully."));
+};
+
+export const setupVitest = async (
+	projectDir: string,
+	useTypescript: boolean,
+) => {
+	console.log(chalk.yellow("Setting up Vitest..."));
+
+	// Install Vitest and related packages
+	execSync(
+		"npm install -D vitest jsdom @testing-library/react @testing-library/jest-dom",
+		{ stdio: "inherit" },
+	);
+
+	const fileExtension = useTypescript ? "ts" : "js";
+	const testFileExtension = useTypescript ? "tsx" : "jsx";
+
+	// Create a basic Vitest config file
+	const vitestConfigContent = `
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/setup.${fileExtension}',
+  },
+})
+`;
+	fs.writeFileSync(
+		path.join(projectDir, `vitest.config.${fileExtension}`),
+		vitestConfigContent,
+	);
+
+	// Create a setup file for tests
+	const setupFileContent = `
+import '@testing-library/jest-dom'
+`;
+	fs.mkdirSync(path.join(projectDir, "src", "test"), { recursive: true });
+	fs.writeFileSync(
+		path.join(projectDir, "src", "test", `setup.${fileExtension}`),
+		setupFileContent,
+	);
+
+	// Create an example test file
+	const exampleTestContent = `
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import App from '../App'
+
+describe('App', () => {
+  it('renders hello world', () => {
+    render(<App />)
+    expect(screen.getByText('Hello World')).toBeInTheDocument()
+  })
+})
+`;
+	fs.writeFileSync(
+		path.join(projectDir, `src/App.test.${testFileExtension}`),
+		exampleTestContent,
+	);
+
+	// Add test script to package.json
+	const packageJsonPath = path.join(projectDir, "package.json");
+	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+	packageJson.scripts.test = "vitest";
+	fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+	console.log(chalk.green("Vitest setup completed successfully."));
 };
 
 export const checkForUpdates = () => {
-  try {
-    const latestVersion = execSync('npm show vtta version').toString().trim(); // Replace 'vtta' with your actual package name
-    const currentVersion = packageJson.version;
+	try {
+		const latestVersion = execSync("npm show vtta version").toString().trim(); // Replace 'vtta' with your actual package name
+		const currentVersion = packageJson.version;
 
-    if (latestVersion !== currentVersion) {
-      console.log(
-        chalk.yellow(`A new version (${latestVersion}) of vtta is available.`)
-      );
-      console.log(chalk.green(`Update by running: npm install -g vtta`));
-      console.log(chalk.blueBright(`Or use npx vtta@latest <project-name>`));
-    }
-  } catch (err) {
-    console.error(chalk.red('Error checking for updates:'), err);
-  }
+		if (latestVersion !== currentVersion) {
+			console.log(
+				chalk.yellow(`A new version (${latestVersion}) of vtta is available.`),
+			);
+			console.log(chalk.green(`Update by running: npm install -g vtta`));
+			console.log(chalk.blueBright(`Or use npx vtta@latest <project-name>`));
+		}
+	} catch (err) {
+		console.error(chalk.red("Error checking for updates:"), err);
+	}
 };


### PR DESCRIPTION
## Description

Implements the vitest project starter option feature request as detailed in this issue: https://github.com/dane-whitfield/vtta/issues/9

## What?

Adds vitest as a project option when creating the project, it ensures to respect the users JavaScript or TypeScript setup.

## Why?

Currently when people generate the projects, test setups are missing by default, it would make sense that we introduce this as a setup option when generating new projects from vtta so that we hit "another bird" with the same stone so to speak.

## Checklist

- [x] I have followed the coding guidelines.
- [x] Added tests if applicable and tests are passing locally.
- [x] Linting is passing.
