### PR TITLE
chore: update deps

### DIFF
--- a/.changeset/popular-cougars-approve.md
+++ b/.changeset/popular-cougars-approve.md
@@ -1,0 +1,5 @@
+---
+"vtta": patch
+---
+
+Update deps

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
 	"name": "vtta",
-	"version": "1.6.1",
+	"version": "1.6.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vtta",
-			"version": "1.6.1",
+			"version": "1.6.2",
 			"license": "MIT",
 			"dependencies": {
 				"@changesets/cli": "^2.27.9",
 				"biome": "^0.3.3",
 				"chalk": "^5.3.0",
-				"commander": "^10.0.1",
+				"commander": "^12.1.0",
 				"fs-extra": "^11.2.0",
-				"inquirer": "^10.2.2"
+				"inquirer": "^12.0.1"
 			},
 			"bin": {
 				"vtta": "dist/src/cli.js"
@@ -24,11 +24,11 @@
 				"@commitlint/cli": "^19.5.0",
 				"@commitlint/config-conventional": "^19.5.0",
 				"@types/fs-extra": "^11.0.4",
-				"@types/node": "^22.5.5",
-				"@vitest/ui": "^2.1.1",
-				"lefthook": "^1.7.18",
-				"typescript": "^5.6.2",
-				"vitest": "^2.1.1"
+				"@types/node": "^22.8.6",
+				"@vitest/ui": "^2.1.4",
+				"lefthook": "^1.8.2",
+				"typescript": "^5.6.3",
+				"vitest": "^2.1.4"
 			},
 			"engines": {
 				"node": ">=18"
@@ -1215,45 +1215,48 @@
 			}
 		},
 		"node_modules/@inquirer/checkbox": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-2.5.0.tgz",
-			"integrity": "sha512-sMgdETOfi2dUHT8r7TT1BTKOwNvdDGFDXYWtQ2J69SvlYNntk9I/gJe7r5yvMwwsuKnYbuRs3pNhx4tgNck5aA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.0.1.tgz",
+			"integrity": "sha512-ehJjmNPdguajc1hStvjN7DJNVjwG5LC1mgGMGFjCmdkn2fxB2GtULftMnlaqNmvMdPpqdaSoOFpl86VkLtG4pQ==",
 			"dependencies": {
-				"@inquirer/core": "^9.1.0",
-				"@inquirer/figures": "^1.0.5",
-				"@inquirer/type": "^1.5.3",
+				"@inquirer/core": "^10.0.1",
+				"@inquirer/figures": "^1.0.7",
+				"@inquirer/type": "^3.0.0",
 				"ansi-escapes": "^4.3.2",
 				"yoctocolors-cjs": "^2.1.2"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/confirm": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.2.0.tgz",
-			"integrity": "sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.1.tgz",
+			"integrity": "sha512-6ycMm7k7NUApiMGfVc32yIPp28iPKxhGRMqoNDiUjq2RyTAkbs5Fx0TdzBqhabcKvniDdAAvHCmsRjnNfTsogw==",
 			"dependencies": {
-				"@inquirer/core": "^9.1.0",
-				"@inquirer/type": "^1.5.3"
+				"@inquirer/core": "^10.0.1",
+				"@inquirer/type": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/core": {
-			"version": "9.2.1",
-			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
-			"integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.0.1.tgz",
+			"integrity": "sha512-KKTgjViBQUi3AAssqjUFMnMO3CM3qwCHvePV9EW+zTKGKafFGFF01sc1yOIYjLJ7QU52G/FbzKc+c01WLzXmVQ==",
 			"dependencies": {
-				"@inquirer/figures": "^1.0.6",
-				"@inquirer/type": "^2.0.0",
-				"@types/mute-stream": "^0.0.4",
-				"@types/node": "^22.5.5",
-				"@types/wrap-ansi": "^3.0.0",
+				"@inquirer/figures": "^1.0.7",
+				"@inquirer/type": "^3.0.0",
 				"ansi-escapes": "^4.3.2",
 				"cli-width": "^4.1.0",
-				"mute-stream": "^1.0.0",
+				"mute-stream": "^2.0.0",
 				"signal-exit": "^4.1.0",
 				"strip-ansi": "^6.0.1",
 				"wrap-ansi": "^6.2.0",
@@ -1263,41 +1266,36 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@inquirer/core/node_modules/@inquirer/type": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
-			"integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
-			"dependencies": {
-				"mute-stream": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@inquirer/editor": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-2.2.0.tgz",
-			"integrity": "sha512-9KHOpJ+dIL5SZli8lJ6xdaYLPPzB8xB9GZItg39MBybzhxA16vxmszmQFrRwbOA918WA2rvu8xhDEg/p6LXKbw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.0.1.tgz",
+			"integrity": "sha512-qAHHJ6hs343eNtCKgV2wV5CImFxYG8J1pl/YCeI5w9VoW7QpulRUU26+4NsMhjR6zDRjKBsH/rRjCIcaAOHsrg==",
 			"dependencies": {
-				"@inquirer/core": "^9.1.0",
-				"@inquirer/type": "^1.5.3",
+				"@inquirer/core": "^10.0.1",
+				"@inquirer/type": "^3.0.0",
 				"external-editor": "^3.1.0"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/expand": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-2.3.0.tgz",
-			"integrity": "sha512-qnJsUcOGCSG1e5DTOErmv2BPQqrtT6uzqn1vI/aYGiPKq+FgslGZmtdnXbhuI7IlT7OByDoEEqdnhUnVR2hhLw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.1.tgz",
+			"integrity": "sha512-9anjpdc802YInXekwePsa5LWySzVMHbhVS6v6n5IJxrl8w09mODOeP69wZ1d0WrOvot2buQSmYp4lW/pq8y+zQ==",
 			"dependencies": {
-				"@inquirer/core": "^9.1.0",
-				"@inquirer/type": "^1.5.3",
+				"@inquirer/core": "^10.0.1",
+				"@inquirer/type": "^3.0.0",
 				"yoctocolors-cjs": "^2.1.2"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/figures": {
@@ -1309,113 +1307,134 @@
 			}
 		},
 		"node_modules/@inquirer/input": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-2.3.0.tgz",
-			"integrity": "sha512-XfnpCStx2xgh1LIRqPXrTNEEByqQWoxsWYzNRSEUxJ5c6EQlhMogJ3vHKu8aXuTacebtaZzMAHwEL0kAflKOBw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.0.1.tgz",
+			"integrity": "sha512-m+SliZ2m43cDRIpAdQxfv5QOeAQCuhS8TGLvtzEP1An4IH1kBES4RLMRgE/fC+z29aN8qYG8Tq/eXQQKTYwqAg==",
 			"dependencies": {
-				"@inquirer/core": "^9.1.0",
-				"@inquirer/type": "^1.5.3"
+				"@inquirer/core": "^10.0.1",
+				"@inquirer/type": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/number": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-1.1.0.tgz",
-			"integrity": "sha512-ilUnia/GZUtfSZy3YEErXLJ2Sljo/mf9fiKc08n18DdwdmDbOzRcTv65H1jjDvlsAuvdFXf4Sa/aL7iw/NanVA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.1.tgz",
+			"integrity": "sha512-gF3erqfm0snpwBjbyKXUUe17QJ7ebm49btXApajrM0rgCCoYX0o9W5NCuYNae87iPxaIJVjtuoQ42DX32IdbMA==",
 			"dependencies": {
-				"@inquirer/core": "^9.1.0",
-				"@inquirer/type": "^1.5.3"
+				"@inquirer/core": "^10.0.1",
+				"@inquirer/type": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/password": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-2.2.0.tgz",
-			"integrity": "sha512-5otqIpgsPYIshqhgtEwSspBQE40etouR8VIxzpJkv9i0dVHIpyhiivbkH9/dGiMLdyamT54YRdGJLfl8TFnLHg==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.1.tgz",
+			"integrity": "sha512-D7zUuX4l4ZpL3D7/SWu9ibijP09jigwHi/gfUHLx5GMS5oXzuMfPV2xPMG1tskco4enTx70HA0VtMXecerpvbg==",
 			"dependencies": {
-				"@inquirer/core": "^9.1.0",
-				"@inquirer/type": "^1.5.3",
+				"@inquirer/core": "^10.0.1",
+				"@inquirer/type": "^3.0.0",
 				"ansi-escapes": "^4.3.2"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/prompts": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-5.5.0.tgz",
-			"integrity": "sha512-BHDeL0catgHdcHbSFFUddNzvx/imzJMft+tWDPwTm3hfu8/tApk1HrooNngB2Mb4qY+KaRWF+iZqoVUPeslEog==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.0.1.tgz",
+			"integrity": "sha512-cu2CpGC2hz7WTt2VBvdkzahDvYice6vYA/8Dm7Fy3tRNzKuQTF2EY3CV4H2GamveWE6tA2XzyXtbWX8+t4WMQg==",
 			"dependencies": {
-				"@inquirer/checkbox": "^2.5.0",
-				"@inquirer/confirm": "^3.2.0",
-				"@inquirer/editor": "^2.2.0",
-				"@inquirer/expand": "^2.3.0",
-				"@inquirer/input": "^2.3.0",
-				"@inquirer/number": "^1.1.0",
-				"@inquirer/password": "^2.2.0",
-				"@inquirer/rawlist": "^2.3.0",
-				"@inquirer/search": "^1.1.0",
-				"@inquirer/select": "^2.5.0"
+				"@inquirer/checkbox": "^4.0.1",
+				"@inquirer/confirm": "^5.0.1",
+				"@inquirer/editor": "^4.0.1",
+				"@inquirer/expand": "^4.0.1",
+				"@inquirer/input": "^4.0.1",
+				"@inquirer/number": "^3.0.1",
+				"@inquirer/password": "^4.0.1",
+				"@inquirer/rawlist": "^4.0.1",
+				"@inquirer/search": "^3.0.1",
+				"@inquirer/select": "^4.0.1"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/rawlist": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-2.3.0.tgz",
-			"integrity": "sha512-zzfNuINhFF7OLAtGHfhwOW2TlYJyli7lOUoJUXw/uyklcwalV6WRXBXtFIicN8rTRK1XTiPWB4UY+YuW8dsnLQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.1.tgz",
+			"integrity": "sha512-0LuMOgaWs7W8JNcbiKkoFwyWFDEeCmLqDCygF0hidQUVa6J5grFVRZxrpompiWDFM49Km2rf7WoZwRo1uf1yWQ==",
 			"dependencies": {
-				"@inquirer/core": "^9.1.0",
-				"@inquirer/type": "^1.5.3",
+				"@inquirer/core": "^10.0.1",
+				"@inquirer/type": "^3.0.0",
 				"yoctocolors-cjs": "^2.1.2"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/search": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-1.1.0.tgz",
-			"integrity": "sha512-h+/5LSj51dx7hp5xOn4QFnUaKeARwUCLs6mIhtkJ0JYPBLmEYjdHSYh7I6GrLg9LwpJ3xeX0FZgAG1q0QdCpVQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.1.tgz",
+			"integrity": "sha512-ehMqjiO0pAf+KtdONKeCLVy4i3fy3feyRRhDrvzWhiwB8JccgKn7eHFr39l+Nx/FaZAhr0YxIJvkK5NuNvG+Ww==",
 			"dependencies": {
-				"@inquirer/core": "^9.1.0",
-				"@inquirer/figures": "^1.0.5",
-				"@inquirer/type": "^1.5.3",
+				"@inquirer/core": "^10.0.1",
+				"@inquirer/figures": "^1.0.7",
+				"@inquirer/type": "^3.0.0",
 				"yoctocolors-cjs": "^2.1.2"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/select": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.5.0.tgz",
-			"integrity": "sha512-YmDobTItPP3WcEI86GvPo+T2sRHkxxOq/kXmsBjHS5BVXUgvgZ5AfJjkvQvZr03T81NnI3KrrRuMzeuYUQRFOA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.1.tgz",
+			"integrity": "sha512-tVRatFRGU49bxFCKi/3P+C0E13KZduNFbWuHWRx0L2+jbiyKRpXgHp9qiRHWRk/KarhYBXzH/di6w3VQ5aJd5w==",
 			"dependencies": {
-				"@inquirer/core": "^9.1.0",
-				"@inquirer/figures": "^1.0.5",
-				"@inquirer/type": "^1.5.3",
+				"@inquirer/core": "^10.0.1",
+				"@inquirer/figures": "^1.0.7",
+				"@inquirer/type": "^3.0.0",
 				"ansi-escapes": "^4.3.2",
 				"yoctocolors-cjs": "^2.1.2"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
 			}
 		},
 		"node_modules/@inquirer/type": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
-			"integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
-			"dependencies": {
-				"mute-stream": "^1.0.0"
-			},
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.0.tgz",
+			"integrity": "sha512-YYykfbw/lefC7yKj7nanzQXILM7r3suIvyFlCcMskc99axmsSewXWkAfXKwMbgxL76iAFVmRwmYdwNZNc8gjog==",
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
@@ -1597,9 +1616,9 @@
 			"dev": true
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
-			"integrity": "sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.3.tgz",
+			"integrity": "sha512-ufb2CH2KfBWPJok95frEZZ82LtDl0A6QKTa8MoM+cWwDZvVGl5/jNb79pIhRvAalUu+7LD91VYR0nwRD799HkQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1610,9 +1629,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.0.tgz",
-			"integrity": "sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.3.tgz",
+			"integrity": "sha512-iAHpft/eQk9vkWIV5t22V77d90CRofgR2006UiCjHcHJFVI1E0oBkQIAbz+pLtthFw3hWEmVB4ilxGyBf48i2Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1623,9 +1642,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz",
-			"integrity": "sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.3.tgz",
+			"integrity": "sha512-QPW2YmkWLlvqmOa2OwrfqLJqkHm7kJCIMq9kOz40Zo9Ipi40kf9ONG5Sz76zszrmIZZ4hgRIkez69YnTHgEz1w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1636,9 +1655,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.0.tgz",
-			"integrity": "sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.3.tgz",
+			"integrity": "sha512-KO0pN5x3+uZm1ZXeIfDqwcvnQ9UEGN8JX5ufhmgH5Lz4ujjZMAnxQygZAVGemFWn+ZZC0FQopruV4lqmGMshow==",
 			"cpu": [
 				"x64"
 			],
@@ -1648,10 +1667,36 @@
 				"darwin"
 			]
 		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.24.3.tgz",
+			"integrity": "sha512-CsC+ZdIiZCZbBI+aRlWpYJMSWvVssPuWqrDy/zi9YfnatKKSLFCe6fjna1grHuo/nVaHG+kiglpRhyBQYRTK4A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.24.3.tgz",
+			"integrity": "sha512-F0nqiLThcfKvRQhZEzMIXOQG4EeX61im61VYL1jo4eBxv4aZRmpin6crnBJQ/nWnCsjH5F6J3W6Stdm0mBNqBg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.0.tgz",
-			"integrity": "sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.3.tgz",
+			"integrity": "sha512-KRSFHyE/RdxQ1CSeOIBVIAxStFC/hnBgVcaiCkQaVC+EYDtTe4X7z5tBkFyRoBgUGtB6Xg6t9t2kulnX6wJc6A==",
 			"cpu": [
 				"arm"
 			],
@@ -1662,9 +1707,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.0.tgz",
-			"integrity": "sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.3.tgz",
+			"integrity": "sha512-h6Q8MT+e05zP5BxEKz0vi0DhthLdrNEnspdLzkoFqGwnmOzakEHSlXfVyA4HJ322QtFy7biUAVFPvIDEDQa6rw==",
 			"cpu": [
 				"arm"
 			],
@@ -1675,9 +1720,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.0.tgz",
-			"integrity": "sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.3.tgz",
+			"integrity": "sha512-fKElSyXhXIJ9pqiYRqisfirIo2Z5pTTve5K438URf08fsypXrEkVmShkSfM8GJ1aUyvjakT+fn2W7Czlpd/0FQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1688,9 +1733,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.0.tgz",
-			"integrity": "sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.3.tgz",
+			"integrity": "sha512-YlddZSUk8G0px9/+V9PVilVDC6ydMz7WquxozToozSnfFK6wa6ne1ATUjUvjin09jp34p84milxlY5ikueoenw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1701,9 +1746,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.0.tgz",
-			"integrity": "sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.3.tgz",
+			"integrity": "sha512-yNaWw+GAO8JjVx3s3cMeG5Esz1cKVzz8PkTJSfYzE5u7A+NvGmbVFEHP+BikTIyYWuz0+DX9kaA3pH9Sqxp69g==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1714,9 +1759,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.0.tgz",
-			"integrity": "sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.3.tgz",
+			"integrity": "sha512-lWKNQfsbpv14ZCtM/HkjCTm4oWTKTfxPmr7iPfp3AHSqyoTz5AgLemYkWLwOBWc+XxBbrU9SCokZP0WlBZM9lA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1727,9 +1772,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.0.tgz",
-			"integrity": "sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.3.tgz",
+			"integrity": "sha512-HoojGXTC2CgCcq0Woc/dn12wQUlkNyfH0I1ABK4Ni9YXyFQa86Fkt2Q0nqgLfbhkyfQ6003i3qQk9pLh/SpAYw==",
 			"cpu": [
 				"s390x"
 			],
@@ -1740,9 +1785,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
-			"integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.3.tgz",
+			"integrity": "sha512-mnEOh4iE4USSccBOtcrjF5nj+5/zm6NcNhbSEfR3Ot0pxBwvEn5QVUXcuOwwPkapDtGZ6pT02xLoPaNv06w7KQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1753,9 +1798,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
-			"integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.3.tgz",
+			"integrity": "sha512-rMTzawBPimBQkG9NKpNHvquIUTQPzrnPxPbCY1Xt+mFkW7pshvyIS5kYgcf74goxXOQk0CP3EoOC1zcEezKXhw==",
 			"cpu": [
 				"x64"
 			],
@@ -1766,9 +1811,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.0.tgz",
-			"integrity": "sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.3.tgz",
+			"integrity": "sha512-2lg1CE305xNvnH3SyiKwPVsTVLCg4TmNCF1z7PSHX2uZY2VbUpdkgAllVoISD7JO7zu+YynpWNSKAtOrX3AiuA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1779,9 +1824,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.0.tgz",
-			"integrity": "sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.3.tgz",
+			"integrity": "sha512-9SjYp1sPyxJsPWuhOCX6F4jUMXGbVVd5obVpoVEi8ClZqo52ViZewA6eFz85y8ezuOA+uJMP5A5zo6Oz4S5rVQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -1792,9 +1837,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz",
-			"integrity": "sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.3.tgz",
+			"integrity": "sha512-HGZgRFFYrMrP3TJlq58nR1xy8zHKId25vhmm5S9jETEfDf6xybPxsavFTJaufe2zgOGYJBskGlj49CwtEuFhWQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1838,36 +1883,23 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/mute-stream": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
-			"integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@types/node": {
-			"version": "22.8.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.1.tgz",
-			"integrity": "sha512-k6Gi8Yyo8EtrNtkHXutUu2corfDf9su95VYVP10aGYMMROM6SAItZi0w1XszA6RtWTHSVp5OeFof37w0IEqCQg==",
+			"version": "22.8.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.6.tgz",
+			"integrity": "sha512-tosuJYKrIqjQIlVCM4PEGxOmyg3FCPa/fViuJChnGeEIhjA46oy8FMVoF9su1/v8PNs2a8Q0iFNyOx0uOF91nw==",
 			"dependencies": {
 				"undici-types": "~6.19.8"
 			}
 		},
-		"node_modules/@types/wrap-ansi": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
-			"integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g=="
-		},
 		"node_modules/@vitest/expect": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.3.tgz",
-			"integrity": "sha512-SNBoPubeCJhZ48agjXruCI57DvxcsivVDdWz+SSsmjTT4QN/DfHk3zB/xKsJqMs26bLZ/pNRLnCf0j679i0uWQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.4.tgz",
+			"integrity": "sha512-DOETT0Oh1avie/D/o2sgMHGrzYUFFo3zqESB2Hn70z6QB1HrS2IQ9z5DfyTqU8sg4Bpu13zZe9V4+UTNQlUeQA==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/spy": "2.1.3",
-				"@vitest/utils": "2.1.3",
-				"chai": "^5.1.1",
+				"@vitest/spy": "2.1.4",
+				"@vitest/utils": "2.1.4",
+				"chai": "^5.1.2",
 				"tinyrainbow": "^1.2.0"
 			},
 			"funding": {
@@ -1875,21 +1907,20 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.3.tgz",
-			"integrity": "sha512-eSpdY/eJDuOvuTA3ASzCjdithHa+GIF1L4PqtEELl6Qa3XafdMLBpBlZCIUCX2J+Q6sNmjmxtosAG62fK4BlqQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.4.tgz",
+			"integrity": "sha512-Ky/O1Lc0QBbutJdW0rqLeFNbuLEyS+mIPiNdlVlp2/yhJ0SbyYqObS5IHdhferJud8MbbwMnexg4jordE5cCoQ==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/spy": "2.1.3",
+				"@vitest/spy": "2.1.4",
 				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.11"
+				"magic-string": "^0.30.12"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/spy": "2.1.3",
-				"msw": "^2.3.5",
+				"msw": "^2.4.9",
 				"vite": "^5.0.0"
 			},
 			"peerDependenciesMeta": {
@@ -1902,9 +1933,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.3.tgz",
-			"integrity": "sha512-XH1XdtoLZCpqV59KRbPrIhFCOO0hErxrQCMcvnQete3Vibb9UeIOX02uFPfVn3Z9ZXsq78etlfyhnkmIZSzIwQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.4.tgz",
+			"integrity": "sha512-L95zIAkEuTDbUX1IsjRl+vyBSLh3PwLLgKpghl37aCK9Jvw0iP+wKwIFhfjdUtA2myLgjrG6VU6JCFLv8q/3Ww==",
 			"dev": true,
 			"dependencies": {
 				"tinyrainbow": "^1.2.0"
@@ -1914,12 +1945,12 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.3.tgz",
-			"integrity": "sha512-JGzpWqmFJ4fq5ZKHtVO3Xuy1iF2rHGV4d/pdzgkYHm1+gOzNZtqjvyiaDGJytRyMU54qkxpNzCx+PErzJ1/JqQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.4.tgz",
+			"integrity": "sha512-sKRautINI9XICAMl2bjxQM8VfCMTB0EbsBc/EDFA57V6UQevEKY/TOPOF5nzcvCALltiLfXWbq4MaAwWx/YxIA==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/utils": "2.1.3",
+				"@vitest/utils": "2.1.4",
 				"pathe": "^1.1.2"
 			},
 			"funding": {
@@ -1927,13 +1958,13 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.3.tgz",
-			"integrity": "sha512-qWC2mWc7VAXmjAkEKxrScWHWFyCQx/cmiZtuGqMi+WwqQJ2iURsVY4ZfAK6dVo6K2smKRU6l3BPwqEBvhnpQGg==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.4.tgz",
+			"integrity": "sha512-3Kab14fn/5QZRog5BPj6Rs8dc4B+mim27XaKWFWHWA87R56AKjHTGcBFKpvZKDzC4u5Wd0w/qKsUIio3KzWW4Q==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/pretty-format": "2.1.3",
-				"magic-string": "^0.30.11",
+				"@vitest/pretty-format": "2.1.4",
+				"magic-string": "^0.30.12",
 				"pathe": "^1.1.2"
 			},
 			"funding": {
@@ -1941,46 +1972,46 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.3.tgz",
-			"integrity": "sha512-Nb2UzbcUswzeSP7JksMDaqsI43Sj5+Kry6ry6jQJT4b5gAK+NS9NED6mDb8FlMRCX8m5guaHCDZmqYMMWRy5nQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.4.tgz",
+			"integrity": "sha512-4JOxa+UAizJgpZfaCPKK2smq9d8mmjZVPMt2kOsg/R8QkoRzydHH1qHxIYNvr1zlEaFj4SXiaaJWxq/LPLKaLg==",
 			"dev": true,
 			"dependencies": {
-				"tinyspy": "^3.0.0"
+				"tinyspy": "^3.0.2"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/ui": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-2.1.3.tgz",
-			"integrity": "sha512-2XwTrHVJw3t9NYES26LQUYy51ZB8W4bRPgqUH2Eyda3kIuOlYw1ZdPNU22qcVlUVx4WKgECFQOSXuopsczuVjQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-2.1.4.tgz",
+			"integrity": "sha512-Zd9e5oU063c+j9N9XzGJagCLNvG71x/2tOme3Js4JEZKX55zsgxhJwUgLI8hkN6NjMLpdJO8d7nVUUuPGAA58Q==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/utils": "2.1.3",
+				"@vitest/utils": "2.1.4",
 				"fflate": "^0.8.2",
 				"flatted": "^3.3.1",
 				"pathe": "^1.1.2",
-				"sirv": "^2.0.4",
-				"tinyglobby": "^0.2.6",
+				"sirv": "^3.0.0",
+				"tinyglobby": "^0.2.9",
 				"tinyrainbow": "^1.2.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"vitest": "2.1.3"
+				"vitest": "2.1.4"
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.3.tgz",
-			"integrity": "sha512-xpiVfDSg1RrYT0tX6czgerkpcKFmFOF/gCr30+Mve5V2kewCy4Prn1/NDMSRwaSmT7PRaOF83wu+bEtsY1wrvA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.4.tgz",
+			"integrity": "sha512-MXDnZn0Awl2S86PSNIim5PWXgIAx8CIkzu35mBdSApUip6RFOGXBCf3YFyeEu8n1IHk4bWD46DeYFu9mQlFIRg==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/pretty-format": "2.1.3",
-				"loupe": "^3.1.1",
+				"@vitest/pretty-format": "2.1.4",
+				"loupe": "^3.1.2",
 				"tinyrainbow": "^1.2.0"
 			},
 			"funding": {
@@ -2396,11 +2427,11 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-			"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			}
 		},
 		"node_modules/compare-func": {
@@ -2778,6 +2809,15 @@
 			"integrity": "sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
+			"integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/extend": {
@@ -3249,21 +3289,23 @@
 			}
 		},
 		"node_modules/inquirer": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-10.2.2.tgz",
-			"integrity": "sha512-tyao/4Vo36XnUItZ7DnUXX4f1jVao2mSrleV/5IPtW/XAEA26hRVsbc68nuTEKWcr5vMP/1mVoT2O7u8H4v1Vg==",
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.0.1.tgz",
+			"integrity": "sha512-o11Jc2Go6wDZA17SWofiJ6L8k7mB8lsdKB/QY0bI+8e+ATiAvQzmROjqoTd1iAY8RI6N/EDcQcxbQa4JYviDWg==",
 			"dependencies": {
-				"@inquirer/core": "^9.1.0",
-				"@inquirer/prompts": "^5.5.0",
-				"@inquirer/type": "^1.5.3",
-				"@types/mute-stream": "^0.0.4",
+				"@inquirer/core": "^10.0.1",
+				"@inquirer/prompts": "^7.0.1",
+				"@inquirer/type": "^3.0.0",
 				"ansi-escapes": "^4.3.2",
-				"mute-stream": "^1.0.0",
+				"mute-stream": "^2.0.0",
 				"run-async": "^3.0.0",
 				"rxjs": "^7.8.1"
 			},
 			"engines": {
 				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
 			}
 		},
 		"node_modules/inquirer-promise": {
@@ -3604,31 +3646,31 @@
 			}
 		},
 		"node_modules/lefthook": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.8.1.tgz",
-			"integrity": "sha512-DTm2F7kf+mQ0UgxSOuCSIwAMC4RJOH5x77okcsFfeJOJ0y7/xGgpfmPb9ZPBDXeJ6UxfI0ngRgWoEctYMlMr4A==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.8.2.tgz",
+			"integrity": "sha512-lMXbcFHNDr+gzy/7ghuJDVB/Yyycj+ZL/7pN3Gm/s5Xqrc9+5sj3IrDAPylcEJ1cKCbUnXbwESrhhqpcYv4d4g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
 				"lefthook": "bin/index.js"
 			},
 			"optionalDependencies": {
-				"lefthook-darwin-arm64": "1.8.1",
-				"lefthook-darwin-x64": "1.8.1",
-				"lefthook-freebsd-arm64": "1.8.1",
-				"lefthook-freebsd-x64": "1.8.1",
-				"lefthook-linux-arm64": "1.8.1",
-				"lefthook-linux-x64": "1.8.1",
-				"lefthook-openbsd-arm64": "1.8.1",
-				"lefthook-openbsd-x64": "1.8.1",
-				"lefthook-windows-arm64": "1.8.1",
-				"lefthook-windows-x64": "1.8.1"
+				"lefthook-darwin-arm64": "1.8.2",
+				"lefthook-darwin-x64": "1.8.2",
+				"lefthook-freebsd-arm64": "1.8.2",
+				"lefthook-freebsd-x64": "1.8.2",
+				"lefthook-linux-arm64": "1.8.2",
+				"lefthook-linux-x64": "1.8.2",
+				"lefthook-openbsd-arm64": "1.8.2",
+				"lefthook-openbsd-x64": "1.8.2",
+				"lefthook-windows-arm64": "1.8.2",
+				"lefthook-windows-x64": "1.8.2"
 			}
 		},
 		"node_modules/lefthook-darwin-arm64": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.8.1.tgz",
-			"integrity": "sha512-zTUb0NcMWKDqck9UobqJZCzihksk5Dv/D+zD3jrxi50vQvgl4wfTO3sP78WmVdhGkMCyHy5udOB+L72fyJqcdw==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.8.2.tgz",
+			"integrity": "sha512-g41SoFUv8SzHpG1NOPkHUEPhC1tJM5FF3Vo+HESmLmL9cDfd7JncHFPy59rVnC9Q8nOS0rvoik5HTq+3/wcfww==",
 			"cpu": [
 				"arm64"
 			],
@@ -3639,9 +3681,9 @@
 			]
 		},
 		"node_modules/lefthook-darwin-x64": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.8.1.tgz",
-			"integrity": "sha512-f9DY+UBd+g6TZ/nHdNZnfGeWT/0n18bkYi56biKEBXIgRlnuTNCrk0TUiSxlWF2GUQdxHM8YSWDkPRtHLg+3zg==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.8.2.tgz",
+			"integrity": "sha512-IlCm4PrA/aAZ1MChiExYTbladC87GaxmYHOMHCeChLecqn+lypAuiYLgf7w5r2s3MjH5rbXImfU925NRKi6RXQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3652,9 +3694,9 @@
 			]
 		},
 		"node_modules/lefthook-freebsd-arm64": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.8.1.tgz",
-			"integrity": "sha512-ZWx0PtYRtd0tlygUjLKP1eSztyLx2pOnI06h5/PyxWcmF+1/WjYPZM7Mt1nBwpqZcFNYkQ3VefFfg1f0URuLJQ==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.8.2.tgz",
+			"integrity": "sha512-f7AIvuIEXUUR1ZutIFxjYKFDAVUBrdsLm+cbwOCjdfpJh7j2Fjg6nKXbDcglPXlX9Ix+nw9pHbJE2DAgzkI1Vw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3665,9 +3707,9 @@
 			]
 		},
 		"node_modules/lefthook-freebsd-x64": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.8.1.tgz",
-			"integrity": "sha512-F5rd7JMwQJosZclsyqJciAn5CBZCZGTGEXLWEwOhgFZbbsUubGSekAhJNoHFm4eJZaDhhWnckghCjXCfBjDSYg==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.8.2.tgz",
+			"integrity": "sha512-DSDL64fRLSNSWOa1y2bGXwXPiwU1fbAXpj63j6jeQ0jkgu6k+3XL/PBXKh80cI6MvCKz/KQKCtIencXZZ2Ua4Q==",
 			"cpu": [
 				"x64"
 			],
@@ -3678,9 +3720,9 @@
 			]
 		},
 		"node_modules/lefthook-linux-arm64": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.8.1.tgz",
-			"integrity": "sha512-CTsqVHW2B291wLXonod1AMUJEOZqtG8lY+la97Id301kY4TzgbBKQvU2LF/hBIS8c62DjPMzEM4NYfbVzrK1QA==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.8.2.tgz",
+			"integrity": "sha512-sJ95X+ZH8ayIE7ApiGEq5ZF9KGA+eKiocJU+536bLbAIHw5WjGmv2x3llFqUxH/zAmLe3k542oZ4d84wEO0EGQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3691,9 +3733,9 @@
 			]
 		},
 		"node_modules/lefthook-linux-x64": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.8.1.tgz",
-			"integrity": "sha512-fw8WwUjr+mCfH/Gbmfj/7J0oX8NjfaACUQlYr3kVHz3c+LYMoRv7O/7dn2OXVO5vEdK5zH/NZlMml4C4qhxwEA==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.8.2.tgz",
+			"integrity": "sha512-2eirc61M0WjlbSHamAgGf9iWsQTYz4IT6PAPm66vUaeG34+5D66xFicIV6pK2niRGUOPtNs8Kt4lboKtW+ba5g==",
 			"cpu": [
 				"x64"
 			],
@@ -3704,9 +3746,9 @@
 			]
 		},
 		"node_modules/lefthook-openbsd-arm64": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.8.1.tgz",
-			"integrity": "sha512-Za9K1ZAoRRM2Pq0eXZHbUppUZArZfgVcTDawKf/FRkbvAsTnBPEcH8Qtjcsm12qLQZ45KtPzZ/GEl/nxnWpeVQ==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.8.2.tgz",
+			"integrity": "sha512-ZMop7htaSwP3MiL06WHUV36EX05N33o0WzNzC8NO5KEubn8Z74vbXcaq6qYezmgi+erkG6dtTnlbcZy5PFvFIA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3717,9 +3759,9 @@
 			]
 		},
 		"node_modules/lefthook-openbsd-x64": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.8.1.tgz",
-			"integrity": "sha512-NgzcIouZobNZw1eEIC3Vh3z4bzVgIGIyJ41g5PGe6d1IXVkmnc5qpFP7jgnaaLK7TPahzIOREQrtYgR62Hg5bw==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.8.2.tgz",
+			"integrity": "sha512-jXFoxmpYXO6ZafgQJVvk3MYlRgOBJD3n7H8A1Bj1E2yrLzOhKevUKlTNwZTxQdxlnvoo33yD6SjVSujZavEGpw==",
 			"cpu": [
 				"x64"
 			],
@@ -3730,9 +3772,9 @@
 			]
 		},
 		"node_modules/lefthook-windows-arm64": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.8.1.tgz",
-			"integrity": "sha512-NUIwnV56YLUmHZf+C5gQA9tIdWjdHu5Ql6hNdFbYYrGxNvNFh2juHRaPKHUGjYk5iu9bxgjogw7mHfN+LanBcQ==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.8.2.tgz",
+			"integrity": "sha512-hsQUSk6kmB8E0UMD3Mk6ROoa7qv6XmigfPsn9tFjmbZ2aO+kpBfWitZ5v+gcjNp44yaECs3YTMIfv3QFwXlRCw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3743,9 +3785,9 @@
 			]
 		},
 		"node_modules/lefthook-windows-x64": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.8.1.tgz",
-			"integrity": "sha512-9cnvWe8tYBwUxJFvW/TJ3P4Al+52QJcLdkJJ1aKgr3F7EydPPZk+jWFy0b1SSan1S7M7OuoPC9jcKS3PGjB6tw==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.8.2.tgz",
+			"integrity": "sha512-YypbMhvgAtkL7y+O3OlF81vwua7X4jloBz5hO3fILAuzaGAiPE1VbeuqRweV8VuKK4L/ZVVKqmpesygBUNDp9w==",
 			"cpu": [
 				"x64"
 			],
@@ -3953,11 +3995,11 @@
 			"dev": true
 		},
 		"node_modules/mute-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-			"integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+			"integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/mz": {
@@ -4461,9 +4503,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.24.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
-			"integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
+			"version": "4.24.3",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.3.tgz",
+			"integrity": "sha512-HBW896xR5HGmoksbi3JBDtmVzWiPAYqp7wip50hjQ67JbDz61nyoMPdqu1DvVW9asYb2M65Z20ZHsyJCMqMyDg==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "1.0.6"
@@ -4476,22 +4518,24 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.24.0",
-				"@rollup/rollup-android-arm64": "4.24.0",
-				"@rollup/rollup-darwin-arm64": "4.24.0",
-				"@rollup/rollup-darwin-x64": "4.24.0",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
-				"@rollup/rollup-linux-arm-musleabihf": "4.24.0",
-				"@rollup/rollup-linux-arm64-gnu": "4.24.0",
-				"@rollup/rollup-linux-arm64-musl": "4.24.0",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
-				"@rollup/rollup-linux-riscv64-gnu": "4.24.0",
-				"@rollup/rollup-linux-s390x-gnu": "4.24.0",
-				"@rollup/rollup-linux-x64-gnu": "4.24.0",
-				"@rollup/rollup-linux-x64-musl": "4.24.0",
-				"@rollup/rollup-win32-arm64-msvc": "4.24.0",
-				"@rollup/rollup-win32-ia32-msvc": "4.24.0",
-				"@rollup/rollup-win32-x64-msvc": "4.24.0",
+				"@rollup/rollup-android-arm-eabi": "4.24.3",
+				"@rollup/rollup-android-arm64": "4.24.3",
+				"@rollup/rollup-darwin-arm64": "4.24.3",
+				"@rollup/rollup-darwin-x64": "4.24.3",
+				"@rollup/rollup-freebsd-arm64": "4.24.3",
+				"@rollup/rollup-freebsd-x64": "4.24.3",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.24.3",
+				"@rollup/rollup-linux-arm-musleabihf": "4.24.3",
+				"@rollup/rollup-linux-arm64-gnu": "4.24.3",
+				"@rollup/rollup-linux-arm64-musl": "4.24.3",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.24.3",
+				"@rollup/rollup-linux-riscv64-gnu": "4.24.3",
+				"@rollup/rollup-linux-s390x-gnu": "4.24.3",
+				"@rollup/rollup-linux-x64-gnu": "4.24.3",
+				"@rollup/rollup-linux-x64-musl": "4.24.3",
+				"@rollup/rollup-win32-arm64-msvc": "4.24.3",
+				"@rollup/rollup-win32-ia32-msvc": "4.24.3",
+				"@rollup/rollup-win32-x64-msvc": "4.24.3",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -4610,9 +4654,9 @@
 			}
 		},
 		"node_modules/sirv": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
-			"integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.0.tgz",
+			"integrity": "sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==",
 			"dev": true,
 			"dependencies": {
 				"@polka/url": "^1.0.0-next.24",
@@ -4620,7 +4664,7 @@
 				"totalist": "^3.0.0"
 			},
 			"engines": {
-				"node": ">= 10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/slash": {
@@ -5091,13 +5135,13 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.3.tgz",
-			"integrity": "sha512-I1JadzO+xYX887S39Do+paRePCKoiDrWRRjp9kkG5he0t7RXNvPAJPCQSJqbGN4uCrFFeS3Kj3sLqY8NMYBEdA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.4.tgz",
+			"integrity": "sha512-kqa9v+oi4HwkG6g8ufRnb5AeplcRw8jUF6/7/Qz1qRQOXHImG8YnLbB+LLszENwFnoBl9xIf9nVdCFzNd7GQEg==",
 			"dev": true,
 			"dependencies": {
 				"cac": "^6.7.14",
-				"debug": "^4.3.6",
+				"debug": "^4.3.7",
 				"pathe": "^1.1.2",
 				"vite": "^5.0.0"
 			},
@@ -5112,29 +5156,30 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.3.tgz",
-			"integrity": "sha512-Zrxbg/WiIvUP2uEzelDNTXmEMJXuzJ1kCpbDvaKByFA9MNeO95V+7r/3ti0qzJzrxdyuUw5VduN7k+D3VmVOSA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.4.tgz",
+			"integrity": "sha512-eDjxbVAJw1UJJCHr5xr/xM86Zx+YxIEXGAR+bmnEID7z9qWfoxpHw0zdobz+TQAFOLT+nEXz3+gx6nUJ7RgmlQ==",
 			"dev": true,
 			"dependencies": {
-				"@vitest/expect": "2.1.3",
-				"@vitest/mocker": "2.1.3",
-				"@vitest/pretty-format": "^2.1.3",
-				"@vitest/runner": "2.1.3",
-				"@vitest/snapshot": "2.1.3",
-				"@vitest/spy": "2.1.3",
-				"@vitest/utils": "2.1.3",
-				"chai": "^5.1.1",
-				"debug": "^4.3.6",
-				"magic-string": "^0.30.11",
+				"@vitest/expect": "2.1.4",
+				"@vitest/mocker": "2.1.4",
+				"@vitest/pretty-format": "^2.1.4",
+				"@vitest/runner": "2.1.4",
+				"@vitest/snapshot": "2.1.4",
+				"@vitest/spy": "2.1.4",
+				"@vitest/utils": "2.1.4",
+				"chai": "^5.1.2",
+				"debug": "^4.3.7",
+				"expect-type": "^1.1.0",
+				"magic-string": "^0.30.12",
 				"pathe": "^1.1.2",
 				"std-env": "^3.7.0",
 				"tinybench": "^2.9.0",
-				"tinyexec": "^0.3.0",
-				"tinypool": "^1.0.0",
+				"tinyexec": "^0.3.1",
+				"tinypool": "^1.0.1",
 				"tinyrainbow": "^1.2.0",
 				"vite": "^5.0.0",
-				"vite-node": "2.1.3",
+				"vite-node": "2.1.4",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
@@ -5149,8 +5194,8 @@
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
 				"@types/node": "^18.0.0 || >=20.0.0",
-				"@vitest/browser": "2.1.3",
-				"@vitest/ui": "2.1.3",
+				"@vitest/browser": "2.1.4",
+				"@vitest/ui": "2.1.4",
 				"happy-dom": "*",
 				"jsdom": "*"
 			},

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
 	"engines": {
 		"node": ">=18"
 	},
+	"resolutions": {
+		"lodash": "^4.17.21",
+		"tough-cookie": "^4.1.3"
+	},
 	"scripts": {
 		"build": "rm -rf dist && tsc",
 		"start": "node --no-warnings dist/src/cli.js",
@@ -44,19 +48,19 @@
 		"@changesets/cli": "^2.27.9",
 		"biome": "^0.3.3",
 		"chalk": "^5.3.0",
-		"commander": "^10.0.1",
+		"commander": "^12.1.0",
 		"fs-extra": "^11.2.0",
-		"inquirer": "^10.2.2"
+		"inquirer": "^12.0.1"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
 		"@commitlint/cli": "^19.5.0",
 		"@commitlint/config-conventional": "^19.5.0",
 		"@types/fs-extra": "^11.0.4",
-		"@types/node": "^22.5.5",
-		"@vitest/ui": "^2.1.1",
-		"lefthook": "^1.7.18",
-		"typescript": "^5.6.2",
-		"vitest": "^2.1.1"
+		"@types/node": "^22.8.6",
+		"@vitest/ui": "^2.1.4",
+		"lefthook": "^1.8.2",
+		"typescript": "^5.6.3",
+		"vitest": "^2.1.4"
 	}
 }


### PR DESCRIPTION
## Description

Resolves #41 and adds `resolutions` to `package.json`

## What?

Updates all applicable deps with newer versions

## Why?

Some deps were outdated and required updating as part of #41 
We also had some dependabot noise due to some Lodash promise issues.