### PR TITLE
fix: check release action for changeset PRs

### DIFF
--- a/.changeset/lucky-rice-glow.md
+++ b/.changeset/lucky-rice-glow.md
@@ -1,0 +1,5 @@
+---
+"vtta": patch
+---
+
+Resolves issue #32 by adding a check for changeset branches and not running the release action against them

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   release:
+    if: ${{ !contains(github.ref, 'changeset-release/main') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Description

Fixes: #32 

## What?

Add a check to the release action to see if the branch being merged is just for changesets and only run the action if it's not related to changesets or temp PRs

## Why?

We are getting a lot of noise from failing checks but this is because we are attempting to release changes from temp PRs that only contain changesets