### PR TITLE
fix: update shadcn setup to prevent duplicate vite configs

### DIFF
--- a/.changeset/tidy-turtles-yell.md
+++ b/.changeset/tidy-turtles-yell.md
@@ -1,0 +1,5 @@
+---
+"vtta": patch
+---
+
+Update shadcn setup to use dynamic extensions for .js or .ts when overriding vite config to prevent duplicate config files for vite

--- a/src/__tests__/projectSetup.spec.ts
+++ b/src/__tests__/projectSetup.spec.ts
@@ -96,49 +96,51 @@ describe("setupProject", () => {
 		expect(spyLog).not.toHaveBeenCalled();
 	});
 
-	it("should set up Shadcn if both Tailwind and Shadcn are selected", async () => {
-		const projectDir = "test-project";
-		const userChoices = {
-			typescript: false,
-			tailwind: true,
-			axios: false,
-			shadcn: true,
-			router: false,
-			vitest: false,
-			biome: false,
-		};
+	describe("shadcn", () => {
+		it("should set up Shadcn if both Tailwind and Shadcn are selected", async () => {
+			const projectDir = "test-project";
+			const userChoices = {
+				typescript: false,
+				tailwind: true,
+				axios: false,
+				shadcn: true,
+				router: false,
+				vitest: false,
+				biome: false,
+			};
 
-		await setupProject(projectDir, userChoices);
+			await setupProject(projectDir, userChoices);
 
-		expect(installVite).toHaveBeenCalledWith(false);
-		expect(installDependencies).toHaveBeenCalledWith(userChoices);
-		expect(setupTailwind).toHaveBeenCalledWith(projectDir);
-		expect(setupShadcn).toHaveBeenCalledWith(projectDir);
-		expect(spyLog).not.toHaveBeenCalled();
-	});
+			expect(installVite).toHaveBeenCalledWith(false);
+			expect(installDependencies).toHaveBeenCalledWith(userChoices);
+			expect(setupTailwind).toHaveBeenCalledWith(projectDir);
+			expect(setupShadcn).toHaveBeenCalledWith(projectDir);
+			expect(spyLog).not.toHaveBeenCalled();
+		});
 
-	it("should not set up Shadcn and log an error if Tailwind is not selected", async () => {
-		const projectDir = "test-project";
-		const userChoices = {
-			typescript: false,
-			tailwind: false,
-			axios: false,
-			shadcn: true,
-			router: false,
-			vitest: false,
-			biome: false,
-		};
+		it("should not set up Shadcn and log an error if Tailwind is not selected", async () => {
+			const projectDir = "test-project";
+			const userChoices = {
+				typescript: false,
+				tailwind: false,
+				axios: false,
+				shadcn: true,
+				router: false,
+				vitest: false,
+				biome: false,
+			};
 
-		await setupProject(projectDir, userChoices);
+			await setupProject(projectDir, userChoices);
 
-		expect(installVite).toHaveBeenCalledWith(false);
-		expect(installDependencies).toHaveBeenCalledWith(userChoices);
-		expect(setupShadcn).not.toHaveBeenCalled();
-		expect(spyLog).toHaveBeenCalledWith(
-			chalk.red(
-				"Shadcn requires Tailwind and cannot be used without it. Please start again and choose to install Tailwind if you wish to use Shadcn.",
-			),
-		);
+			expect(installVite).toHaveBeenCalledWith(false);
+			expect(installDependencies).toHaveBeenCalledWith(userChoices);
+			expect(setupShadcn).not.toHaveBeenCalled();
+			expect(spyLog).toHaveBeenCalledWith(
+				chalk.red(
+					"Shadcn requires Tailwind and cannot be used without it. Please start again and choose to install Tailwind if you wish to use Shadcn.",
+				),
+			);
+		});
 	});
 
 	it("should handle a full setup with Tailwind, Axios, and Shadcn", async () => {
@@ -163,60 +165,62 @@ describe("setupProject", () => {
 		expect(spyLog).not.toHaveBeenCalled();
 	});
 
-	it("should set up Vitest with JavaScript if TypeScript is not selected", async () => {
-		const projectDir = "test-project";
-		const userChoices = {
-			typescript: false,
-			tailwind: false,
-			axios: false,
-			shadcn: false,
-			vitest: true,
-			router: false,
-			biome: false,
-		};
+	describe("vitest", () => {
+		it("should set up Vitest with JavaScript if TypeScript is not selected", async () => {
+			const projectDir = "test-project";
+			const userChoices = {
+				typescript: false,
+				tailwind: false,
+				axios: false,
+				shadcn: false,
+				vitest: true,
+				router: false,
+				biome: false,
+			};
 
-		await setupProject(projectDir, userChoices);
+			await setupProject(projectDir, userChoices);
 
-		expect(setupVitest).toHaveBeenCalledWith(projectDir, false);
-	});
+			expect(setupVitest).toHaveBeenCalledWith(projectDir, false);
+		});
 
-	it("should set up Vitest with TypeScript if TypeScript is selected", async () => {
-		const projectDir = "test-project";
-		const userChoices = {
-			typescript: true,
-			tailwind: false,
-			axios: false,
-			shadcn: false,
-			vitest: true,
-			router: false,
-			biome: false,
-		};
+		it("should set up Vitest with TypeScript if TypeScript is selected", async () => {
+			const projectDir = "test-project";
+			const userChoices = {
+				typescript: true,
+				tailwind: false,
+				axios: false,
+				shadcn: false,
+				vitest: true,
+				router: false,
+				biome: false,
+			};
 
-		await setupProject(projectDir, userChoices);
+			await setupProject(projectDir, userChoices);
 
-		expect(setupVitest).toHaveBeenCalledWith(projectDir, true);
-	});
+			expect(setupVitest).toHaveBeenCalledWith(projectDir, true);
+		});
 
-	it("should handle a full setup including Vitest", async () => {
-		const projectDir = "test-project";
-		const userChoices = {
-			typescript: true,
-			tailwind: true,
-			axios: true,
-			shadcn: true,
-			vitest: true,
-			router: false,
-			biome: false,
-		};
+		it("should handle a full setup including Vitest", async () => {
+			const projectDir = "test-project";
+			const userChoices = {
+				typescript: true,
+				tailwind: true,
+				axios: true,
+				shadcn: true,
+				vitest: true,
+				router: false,
+				biome: false,
+			};
 
-		await setupProject(projectDir, userChoices);
+			await setupProject(projectDir, userChoices);
 
-		expect(installVite).toHaveBeenCalledWith(true);
-		expect(installDependencies).toHaveBeenCalledWith(userChoices);
-		expect(setupTailwind).toHaveBeenCalledWith(projectDir);
-		expect(setupAxios).toHaveBeenCalledWith(projectDir);
-		expect(setupShadcn).toHaveBeenCalledWith(projectDir);
-		expect(setupVitest).toHaveBeenCalledWith(projectDir, true);
+			expect(installVite).toHaveBeenCalledWith(true);
+			expect(installDependencies).toHaveBeenCalledWith(userChoices);
+			expect(setupTailwind).toHaveBeenCalledWith(projectDir);
+			expect(setupAxios).toHaveBeenCalledWith(projectDir);
+			expect(setupShadcn).toHaveBeenCalledWith(projectDir);
+			expect(setupVitest).toHaveBeenCalledWith(projectDir, true);
+		});
 	});
 
 	describe("biome", () => {

--- a/src/utils/setupShadcn.ts
+++ b/src/utils/setupShadcn.ts
@@ -3,67 +3,76 @@ import fs from "node:fs";
 import path from "node:path";
 import chalk from "chalk";
 
-export const setupShadcn = async (projectDir: string) => {
+export const setupShadcn = async (
+	projectDir: string,
+	useTypescript: boolean,
+) => {
 	console.log(chalk.yellow("Setting up shadcn/ui..."));
 
-	// 1. Update tsconfig.json and tsconfig.app.json with hardcoded content first
-	const tsconfigPath = path.join(projectDir, "tsconfig.json");
-	const tsconfigAppPath = path.join(projectDir, "tsconfig.app.json");
+	// 1. Update tsconfig files only if TypeScript is enabled
+	if (useTypescript) {
+		const tsconfigPath = path.join(projectDir, "tsconfig.json");
+		const tsconfigAppPath = path.join(projectDir, "tsconfig.app.json");
 
-	const tsconfigContent = `{
-    "compilerOptions": {
-      "target": "ES2020",
-      "useDefineForClassFields": true,
-      "lib": ["ES2020", "DOM", "DOM.Iterable"],
-      "module": "ESNext",
-      "skipLibCheck": true,
+		const tsconfigContent = `{
+			"compilerOptions": {
+			  "target": "ES2020",
+			  "useDefineForClassFields": true,
+			  "lib": ["ES2020", "DOM", "DOM.Iterable"],
+			  "module": "ESNext",
+			  "skipLibCheck": true,
 
-      /* Bundler mode */
-      "moduleResolution": "bundler",
-      "allowImportingTsExtensions": true,
-      "resolveJsonModule": true,
-      "isolatedModules": true,
-      "noEmit": true,
-      "jsx": "react-jsx",
+			  /* Bundler mode */
+			  "moduleResolution": "bundler",
+			  "allowImportingTsExtensions": true,
+			  "resolveJsonModule": true,
+			  "isolatedModules": true,
+			  "noEmit": true,
+			  "jsx": "react-jsx",
 
-      /* Linting */
-      "strict": true,
-      "noUnusedLocals": true,
-      "noUnusedParameters": true,
-      "noFallthroughCasesInSwitch": true,
+			  /* Linting */
+			  "strict": true,
+			  "noUnusedLocals": true,
+			  "noUnusedParameters": true,
+			  "noFallthroughCasesInSwitch": true,
 
-      /* shadcn */
-      "baseUrl": ".",
-      "paths": {
-        "@/*": ["./src/*"]
-      }
-    },
-    "include": ["src"],
-    "references": [{ "path": "./tsconfig.node.json" }]
-  }`;
+			  /* shadcn */
+			  "baseUrl": ".",
+			  "paths": {
+				"@/*": ["./src/*"]
+			  }
+			},
+			"include": ["src"],
+			"references": [{ "path": "./tsconfig.node.json" }]
+		  }`;
 
-	// Write tsconfig.json
-	try {
-		fs.writeFileSync(tsconfigPath, tsconfigContent);
-		console.log(chalk.green("tsconfig.json updated successfully."));
-	} catch (error) {
-		console.error(chalk.red("Error updating tsconfig.json:"), error);
-		process.exit(1);
+		// Write tsconfig.json
+		try {
+			fs.writeFileSync(tsconfigPath, tsconfigContent);
+			console.log(chalk.green("tsconfig.json updated successfully."));
+		} catch (error) {
+			console.error(chalk.red("Error updating tsconfig.json:"), error);
+			process.exit(1);
+		}
+
+		// Write tsconfig.app.json (if needed)
+		try {
+			fs.writeFileSync(tsconfigAppPath, tsconfigContent);
+			console.log(chalk.green("tsconfig.app.json updated successfully."));
+		} catch (error) {
+			console.error(chalk.red("Error updating tsconfig.app.json:"), error);
+			process.exit(1);
+		}
 	}
 
-	// Write tsconfig.app.json (if needed)
-	try {
-		fs.writeFileSync(tsconfigAppPath, tsconfigContent);
-		console.log(chalk.green("tsconfig.app.json updated successfully."));
-	} catch (error) {
-		console.error(chalk.red("Error updating tsconfig.app.json:"), error);
-		process.exit(1);
-	}
+	// 2. Set up vite.config with appropriate extension
+	const viteConfigExtension = useTypescript ? "ts" : "js";
+	const viteConfigPath = path.join(
+		projectDir,
+		`vite.config.${viteConfigExtension}`,
+	);
 
-	// 2. Overwrite vite.config.ts with hardcoded content
-	const viteConfigPath = path.join(projectDir, "vite.config.ts");
-
-	// Hardcoded content for vite.config.ts
+	// Hardcoded content for vite.config
 	const viteConfigContent = `import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
@@ -80,13 +89,18 @@ export default defineConfig({
 `;
 
 	try {
-		// Write or overwrite vite.config.ts with hardcoded content
+		// Write or overwrite vite.config with the correct extension
 		fs.writeFileSync(viteConfigPath, viteConfigContent);
 		console.log(
-			chalk.green("vite.config.ts file created/updated successfully."),
+			chalk.green(
+				`vite.config.${viteConfigExtension} file created/updated successfully.`,
+			),
 		);
 	} catch (error) {
-		console.error(chalk.red("Error creating/updating vite.config.ts:"), error);
+		console.error(
+			chalk.red(`Error creating/updating vite.config.${viteConfigExtension}:`),
+			error,
+		);
 		process.exit(1);
 	}
 


### PR DESCRIPTION
## Description

Fixes: #31 

## What?

Updates the shadcn setup to allow for dynamic extension based on whether TS has been selected by the user, using `.js` or `.ts` respectively.

## Why?

To prevent duplicate vite.config files when shadcn is being initialised